### PR TITLE
Fix deprecation warning in Mapping import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 build/
 dist/
 pyhumps.egg-info/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class

--- a/humps/main.py
+++ b/humps/main.py
@@ -4,7 +4,12 @@ This module contains all the core logic for humps.
 """
 import re
 import sys
-from collections import Mapping
+
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
+
 
 _ver = sys.version_info
 is_py2 = (_ver[0] == 2)


### PR DESCRIPTION
## Status
READY

## Description
This PR fixes the deprecation warning raised during pytest:
```
humps/main.py:7
  /Users/lewtun/git/humps/humps/main.py:7: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import Mapping

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

I also took the liberty to add pycache to the gitignore.


## Related PRs
None