### PR TITLE
Point to the right package on PyPI

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ Release v\ |version|. (:ref:`Installation <install>`)
 
 .. image:: https://img.shields.io/pypi/v/pyhumps.svg
   :alt: Pypi
-  :target: https://pypi.python.org/pypi/humps/
+  :target: https://pypi.python.org/pypi/pyhumps/
 
 .. image:: https://travis-ci.org/nficano/humps.svg?branch=master
    :alt: Build status


### PR DESCRIPTION
## Status
**READY**

## Description
PyPI badge points to the `humps` package, should be `pyhumps`.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Documentation