### PR TITLE
Update `camelize` to handle single character segments

### DIFF
--- a/humps/main.py
+++ b/humps/main.py
@@ -22,7 +22,7 @@ if is_py3:  # pragma: no cover
 ACRONYM_RE = re.compile(r"([A-Z]+)$|([A-Z]+)(?=[A-Z0-9])")
 PASCAL_RE = re.compile(r"([^\-_\s]+)")
 SPLIT_RE = re.compile(r"([\-_\s]*[A-Z]+[^A-Z\-_\s]+[\-_\s]*)")
-UNDERSCORE_RE = re.compile(r"([^\-_\s])[\-_\s]+([^\-_\s])")
+UNDERSCORE_RE = re.compile(r"(?<=[^\-_\s])[\-_\s]+([^\-_\s])")
 
 
 def pascalize(str_or_iter):
@@ -85,7 +85,7 @@ def camelize(str_or_iter):
             the regex capture group for "o_w".
         :rtype: str
         """
-        return match.group(1) + match.group(2).upper()
+        return match.group(1).upper()
 
     str_items.extend(
         [

--- a/tests/test_camelize.py
+++ b/tests/test_camelize.py
@@ -23,6 +23,12 @@ import humps
         ("__APIResponse__", "__APIResponse__"),
         # Fixed issue #128
         ("whatever_10", "whatever10"),
+        # Fixed issue # 18
+        ("test-1-2-3-4-5-6", "test123456"),
+        # Fixed issue # 61
+        ("test_n_test", "testNTest"),
+        # Fixed issue # 148
+        ("field_value_2_type", "fieldValue2Type"),
     ],
 )
 def test_camelize(input_str, expected_output):


### PR DESCRIPTION
## Status
READY

## Description
Adjusts `UNDERSCORE_RE` and `_replace_fn` to use positive lookbehind to catch overlapping matches. This change catches single character segments (i.e. "n" in "test_n_test", "2" in "field_value_2_type"). Resolves #18. Resolves #61. Resolves #148.

Prior behavior:
```python
>>> humps.camelize("test-1-2-3-4-5-6")
'test1-23-45-6'
>>> humps.camelize("test_n_test")
'testN_test'
>>> humps.camelize("field_value_2_type")
'fieldValue2_type'
```
New behavior:
```python
>>> humps.camelize("test-1-2-3-4-5-6")
'test123456'
>>> humps.camelize("test_n_test")
'testNTest'
>>> humps.camelize("field_value_2_type")
'fieldValue2Type'
```

## Todos
- [x] Tests

## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* humps.camelize
