### PR TITLE
Drop support for Python 2.7

### DIFF
--- a/humps/main.py
+++ b/humps/main.py
@@ -2,22 +2,9 @@
 This module contains all the core logic for humps.
 """
 import re
-import sys
 
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
+from collections.abc import Mapping
 
-_ver = sys.version_info
-is_py2 = _ver[0] == 2
-is_py3 = _ver[0] == 3
-
-if is_py2:  # pragma: no cover
-    str = unicode  # noqa
-
-if is_py3:  # pragma: no cover
-    str = str
 
 ACRONYM_RE = re.compile(r"([A-Z]+)$|([A-Z]+)(?=[A-Z0-9])")
 PASCAL_RE = re.compile(r"([^\-_\s]+)")

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setuptools.setup(
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
## Status
READY

## Description
Drops support for Python 2.7. Resolves #203.

## Related PRs
N/A

## Todos
- [x] Tests
- [x] Documentation

## Deploy Notes
N/A

## Steps to Test or Reproduce
```sh
git pull --prune
git checkout <feature_branch>
pytest
```

## Impacted Areas in Application