### PR TITLE
Add readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+# python:
+#    install:
+#    - requirements: docs/requirements.txt


### PR DESCRIPTION
## Status
READY

## Description
Add `.readthedocs.yaml` to set build parameters for ReadTheDocs. In particular, set the python version to >3.6 to ensure there are no errors in the build process.

Fixes #214.

## Related PRs
N/A

## Todos
N/A

## Deploy Notes
N/A

## Steps to Test or Reproduce
```sh
git pull --prune
git checkout <feature_branch>
pytest
```
## Impacted Areas in Application
Documentation
