### PR TITLE
Add the ability to between kebab-case and snake_case

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ humps.decamelize(array) # [{'attr_one': 'foo'}, {'attr_one': 'bar'}]
 array = [{'attr_one': 'foo'}, {'attr_one': 'bar'}]
 humps.camelize(array)  # [{'attrOne': 'foo'}, {'attrOne': 'bar'}]
 
+
+array = [{'attr_one': 'foo'}, {'attr_one': 'bar'}]
+humps.kebabize(array)  # [{'attr-one': 'foo'}, {'attr-one': 'bar'}]
+
 array = [{'attr_one': 'foo'}, {'attr_one': 'bar'}]
 humps.pascalize(array)  # [{'AttrOne': 'foo'}, {'AttrOne': 'bar'}]
 ```
@@ -69,6 +73,8 @@ humps.is_pascalcase('ILookIncredible')  # True
 humps.is_snakecase('im_in_this_big_ass_coat')  # True
 humps.is_camelcase('from_that_thrift_shop')  # False
 humps.is_snakecase('downTheRoad')  # False
+humps.is_kebabcase('from_that_thrift_shop')  # False
+humps.is_kebabcase('from-that-thrift-shop')  # True
 
 # what about abbrevations, acronyms, and initialisms? No problem!
 humps.decamelize('APIResponse')  # api_response

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,9 +36,11 @@ Release v\ |version|. (:ref:`Installation <install>`)
     >>> import humps
     >>> humps.decamelize('illWearYourGranddadsClothes')   # 'ill_wear_your_granddads_clothes'
     >>> humps.camelize('i_look_incredible')               # 'iLookIncredible'
+    >>> humps.kebabize('i_look_incredible')               # 'i-look-incredible'
     >>> humps.pascalize('im_in_this_big_ass_coat')        # 'ImInThisBigAssCoat'
     >>> humps.decamelize('FROMThatThriftShop')            # 'from_that_thrift_shop'
     >>> humps.decamelize([{'downTheRoad': True}])         # [{'down_the_road': True}]
+    >>> humps.dekebabize('FROM-That-Thrift-Shop')            # 'FROM_That_Thrift_Shop'
 
 Features
 --------
@@ -46,6 +48,7 @@ Features
 - Convert from ``snake_case`` to ``camelCase`` and ``PascalCase``
 - Convert from ``camelCase`` to ``snake_case`` and ``PascalCase``
 - Convert from ``PascalCase`` to  ``snake_case`` and ``camelCase``
+- Convert from ``kebab-case`` to ``snake_case``
 - Supports recursively converting ``dict`` keys
 - Supports recursively converting lists of dictionaries
 - Gracefully handles abbrevations, acronyms, and initialisms

--- a/humps/__init__.py
+++ b/humps/__init__.py
@@ -12,7 +12,9 @@ __copyright__ = "Copyright 2019 Nick Ficano"
 from humps.main import (
     camelize,
     decamelize,
+    dekebabize,
     depascalize,
+    kebabize,
     is_camelcase,
     is_pascalcase,
     is_snakecase,

--- a/humps/main.py
+++ b/humps/main.py
@@ -66,6 +66,30 @@ def camelize(str_or_iter):
     return UNDERSCORE_RE.sub(lambda m: m.group(0)[-1].upper(), s)
 
 
+def kebabize(str_or_iter):
+    """
+    Convert a string, dict, or list of dicts to kebab case.
+
+    :param str_or_iter:
+        A string or iterable.
+    :type str_or_iter: Union[list, dict, str]
+    :rtype: Union[list, dict, str]
+    :returns:
+        kebabized string, dictionary, or list of dictionaries.
+    """
+    if isinstance(str_or_iter, (list, Mapping)):
+        return _process_keys(str_or_iter, kebabize)
+
+    s = str(str_or_iter)
+    if s.isnumeric():
+        return str_or_iter
+
+    if not s[:2].isupper():
+        s = s[0].lower() + s[1:]
+
+    return UNDERSCORE_RE.sub(lambda m: "-" + m.group(0)[-1], s)
+
+
 def decamelize(str_or_iter):
     """
     Convert a string, dict, or list of dicts to snake case.
@@ -100,6 +124,27 @@ def depascalize(str_or_iter):
     return decamelize(str_or_iter)
 
 
+def dekebabize(str_or_iter):
+    """
+    Convert a string, dict, or list of dicts to snake case.
+
+    :param str_or_iter:
+        A string or iterable.
+    :type str_or_iter: Union[list, dict, str]
+    :rtype: Union[list, dict, str]
+    :returns:
+        snake cased string, dictionary, or list of dictionaries.
+    """
+    if isinstance(str_or_iter, (list, Mapping)):
+        return _process_keys(str_or_iter, dekebabize)
+
+    s = str(str_or_iter)
+    if s.isnumeric():
+        return str_or_iter
+
+    return s.replace("-", "_")
+
+
 def is_camelcase(str_or_iter):
     """
     Determine if a string, dict, or list of dicts is camel case.
@@ -112,6 +157,20 @@ def is_camelcase(str_or_iter):
         True/False whether string or iterable is camel case
     """
     return str_or_iter == camelize(str_or_iter)
+
+
+def is_kebabcase(str_or_iter):
+    """
+    Determine if a string, dict, or list of dicts is camel case.
+
+    :param str_or_iter:
+        A string or iterable.
+    :type str_or_iter: Union[list, dict, str]
+    :rtype: bool
+    :returns:
+        True/False whether string or iterable is camel case
+    """
+    return str_or_iter == kebabize(str_or_iter)
 
 
 def is_pascalcase(str_or_iter):

--- a/tests/test_dekebabize.py
+++ b/tests/test_dekebabize.py
@@ -1,0 +1,103 @@
+"""
+Test dekabization.
+"""
+import pytest
+
+import humps
+
+
+@pytest.mark.parametrize(
+    "input_str, expected_output",
+    [
+        ("symbol", "symbol"),
+        ("last-price", "last_price"),
+        ("Change-Pct", "Change_Pct"),
+        ("implied-Volatility", "implied_Volatility"),
+        ("_symbol", "_symbol"),
+        ("change-pct_", "change_pct_"),
+        ("_last-price__", "_last_price__"),
+        ("__implied-volatility_", "__implied_volatility_"),
+        ("API", "API"),
+        ("_API_", "_API_"),
+        ("__API__", "__API__"),
+        ("API-Response", "API_Response"),
+        ("_API-Response_", "_API_Response_"),
+        ("__API-Response__", "__API_Response__"),
+    ],
+)
+def test_dekebabize(input_str, expected_output):
+    """
+    :param input_str: String that will be transformed.
+    :param expected_output: The expected transformation.
+    """
+    output = humps.dekebabize(input_str)
+    assert output == expected_output, "{} != {}".format(
+        output, expected_output
+    )
+
+
+def test_dekebabize_dict_list():
+    actual = humps.dekebabize(
+        [
+            {
+                "symbol": "AAL",
+                "last-price": 31.78,
+                "Change-Pct": 2.8146,
+                "implied-Volatility": 0.482,
+            },
+            {
+                "symbol": "LBTYA",
+                "last-price": 25.95,
+                "Change-Pct": 2.6503,
+                "implied-Volatility": 0.7287,
+            },
+            {
+                "_symbol": "LBTYK",
+                "Change-Pct_": 2.5827,
+                "_last-price__": 25.42,
+                "__implied-Volatility_": 0.4454,
+            },
+            {
+                "API": "test_upper",
+                "_API_": "test_upper",
+                "__API__": "test_upper",
+                "API-Response": "test_acronym",
+                "_API-Response_": "test_acronym",
+                "__API-Response__": "test_acronym",
+                "ruby_tuesdays": "ruby_tuesdays",
+                "_item-ID": "_item_id",
+            },
+        ]
+    )
+    expected = [
+        {
+            "symbol": "AAL",
+            "last_price": 31.78,
+            "Change_Pct": 2.8146,
+            "implied_Volatility": 0.482,
+        },
+        {
+            "symbol": "LBTYA",
+            "last_price": 25.95,
+            "Change_Pct": 2.6503,
+            "implied_Volatility": 0.7287,
+        },
+        {
+            "_symbol": "LBTYK",
+            "Change_Pct_": 2.5827,
+            "_last_price__": 25.42,
+            "__implied_Volatility_": 0.4454,
+        },
+        {
+            "API": "test_upper",
+            "_API_": "test_upper",
+            "__API__": "test_upper",
+            "API_Response": "test_acronym",
+            "_API_Response_": "test_acronym",
+            "__API_Response__": "test_acronym",
+            "ruby_tuesdays": "ruby_tuesdays",
+            "_item_ID": "_item_id",
+        },
+    ]
+
+    assert actual == expected, "{} != {}".format(actual, expected)

--- a/tests/test_kebabize.py
+++ b/tests/test_kebabize.py
@@ -1,0 +1,102 @@
+"""
+Test kebabization.
+"""
+import pytest
+
+import humps
+
+
+@pytest.mark.parametrize(
+    "input_str, expected_output",
+    [
+        ("fallback_url", "fallback-url"),
+        ("scrubber_media_url", "scrubber-media-url"),
+        ("dash_url", "dash-url"),
+        ("_fallback_url", "_fallback-url"),
+        ("__scrubber_media___url_", "__scrubber-media-url_"),
+        ("_url__", "_url__"),
+        ("API", "API"),
+        ("_API_", "_API_"),
+        ("__API__", "__API__"),
+        ("API_Response", "API-Response"),
+        ("_API_Response_", "_API-Response_"),
+        ("__API_Response__", "__API-Response__"),
+    ],
+)
+def test_kebabize(input_str, expected_output):
+    """
+    :param input_str: String that will be transformed.
+    :param expected_output: The expected transformation.
+    """
+    output = humps.kebabize(input_str)
+    assert output == expected_output, "{} != {}".format(
+        output, expected_output
+    )
+
+
+def test_kebabize_dict_list():
+    actual = humps.kebabize(
+        {
+            "videos": [
+                {
+                    "fallback_url": "https://media.io/video",
+                    "scrubber_Media_Url": "https://media.io/video",
+                    "dash_Url": "https://media.io/video",
+                }
+            ],
+            "images": [
+                {
+                    "fallback_url": "https://media.io/image",
+                    "scrubber_Media_Url": "https://media.io/image",
+                    "url": "https://media.io/image",
+                }
+            ],
+            "other": [
+                {
+                    "_fallback_url": "https://media.io/image",
+                    "__scrubber_Media___Url_": "https://media.io/image",
+                    "_url__": "https://media.io/image",
+                },
+                {
+                    "API": "test_upper",
+                    "_API_": "test_upper",
+                    "__API__": "test_upper",
+                    "APIResponse": "test_acronym",
+                    "_APIResponse_": "test_acronym",
+                    "__APIResponse__": "test_acronym",
+                },
+            ],
+        }
+    )
+    expected = {
+        "videos": [
+            {
+                "fallback-url": "https://media.io/video",
+                "scrubber-Media-Url": "https://media.io/video",
+                "dash-Url": "https://media.io/video",
+            }
+        ],
+        "images": [
+            {
+                "fallback-url": "https://media.io/image",
+                "scrubber-Media-Url": "https://media.io/image",
+                "url": "https://media.io/image",
+            }
+        ],
+        "other": [
+            {
+                "_fallback-url": "https://media.io/image",
+                "__scrubber-Media-Url_": "https://media.io/image",
+                "_url__": "https://media.io/image",
+            },
+            {
+                "API": "test_upper",
+                "_API_": "test_upper",
+                "__API__": "test_upper",
+                "APIResponse": "test_acronym",
+                "_APIResponse_": "test_acronym",
+                "__APIResponse__": "test_acronym",
+            },
+        ],
+    }
+    assert actual == expected


### PR DESCRIPTION
## Status
**READY**

## Description
This can then be combined with the other functions to convert
kebab-case to any other supported case.

Note the character casing is preserved in conversion as I think this
makes the most sense. It can trivially be altered after using lower or
upper.

## Related Issues
Fixes #218 and #180

## Todos
- [x] Tests
- [x] Documentation