### PR TITLE
Fix naming

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,12 @@
 [tool.poetry]
-name = "humps"
+name = "pyhumps"
 version = "3.7.2"
 description = "Convert strings (and dictionary keys) between snake case, camel case and pascal case in Python."
 authors = ["Nick Ficano <nficano@gmail.com>"]
 license = "The Unlicense (Unlicense)"
+packages = [
+    { include = "humps" },
+]
 
 [tool.poetry.dependencies]
 python = "^3.7"


### PR DESCRIPTION
## Status
**READY**

## Description
There was a mismatch for the name and module.

`humps` is the name which is used to import but the module name is [`pyhumps`](https://pypi.org/project/pyhumps/).

Ref: https://github.com/NixOS/nixpkgs/pull/160448
 
## Impacted Areas in Application
List general components of the application that this PR will affect:

* Installation

Migration: #235