### PR TITLE
Fix camelized with inner digits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,14 @@ jobs:
 
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ humps.is_kebabcase('only_got_twenty_dollars_in_my_pocket')  # False
 
 # what about abbrevations, acronyms, and initialisms? No problem!
 humps.decamelize("APIResponse")  # api_response
+humps.decamelize("B52Thing")  # b52_thing
 ```
 
 <hr>

--- a/humps/main.py
+++ b/humps/main.py
@@ -7,7 +7,16 @@ from collections.abc import Mapping  # pylint: disable-msg=E0611
 
 ACRONYM_RE = re.compile(r"([A-Z\d]+)(?=[A-Z\d]|$)")
 PASCAL_RE = re.compile(r"([^\-_]+)")
-SPLIT_RE = re.compile(r"([\-_]*(?<=[^0-9_])(?=[A-Z])[^A-Z]*[\-_]*)")
+SPLIT_RE = re.compile(
+    r"([\-_]*"                                 # optional leading hyphens/underscores
+    r"(?:"                                     # either
+        r"(?<=[^0-9_])(?=[A-Z])"               #   original: non‐digit/non‐underscore → uppercase
+      r"|"                                     # or
+        r"(?<=[0-9])(?=[A-Z][a-z])"            #   digit → uppercase followed by lowercase
+    r")"
+    r"[^A-Z]*"                                 # any non‐uppercase chars
+    r"[\-_]*)"                                 # optional trailing hyphens/underscores
+)
 UNDERSCORE_RE = re.compile(r"(?<=[^\-_])[\-_]+[^\-_]")
 
 

--- a/humps/main.py
+++ b/humps/main.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping  # pylint: disable-msg=E0611
 
 ACRONYM_RE = re.compile(r"([A-Z\d]+)(?=[A-Z\d]|$)")
 PASCAL_RE = re.compile(r"([^\-_]+)")
-SPLIT_RE = re.compile(r"([\-_]*(?<=[^0-9])(?=[A-Z])[^A-Z]*[\-_]*)")
+SPLIT_RE = re.compile(r"([\-_]*(?<=[^0-9_])(?=[A-Z])[^A-Z]*[\-_]*)")
 UNDERSCORE_RE = re.compile(r"(?<=[^\-_])[\-_]+[^\-_]")
 
 

--- a/humps/main.py
+++ b/humps/main.py
@@ -8,14 +8,14 @@ from collections.abc import Mapping  # pylint: disable-msg=E0611
 ACRONYM_RE = re.compile(r"([A-Z\d]+)(?=[A-Z\d]|$)")
 PASCAL_RE = re.compile(r"([^\-_]+)")
 SPLIT_RE = re.compile(
-    r"([\-_]*"                                 # optional leading hyphens/underscores
-    r"(?:"                                     # either
-        r"(?<=[^0-9_])(?=[A-Z])"               #   original: non‐digit/non‐underscore → uppercase
-      r"|"                                     # or
-        r"(?<=[0-9])(?=[A-Z][a-z])"            #   digit → uppercase followed by lowercase
+    r"([\-_]*"                       # optional leading hyphens/underscores
+    r"(?:"                           # either
+    r"(?<=[^0-9_])(?=[A-Z])"         # non‐digit/non‐underscore → uppercase
+    r"|"                             # or
+    r"(?<=[0-9])(?=[A-Z][a-z])"      # digit → uppercase followed by lowercase
     r")"
-    r"[^A-Z]*"                                 # any non‐uppercase chars
-    r"[\-_]*)"                                 # optional trailing hyphens/underscores
+    r"[^A-Z]*"                       # any non‐uppercase chars
+    r"[\-_]*)"                       # optional trailing hyphens/underscores
 )
 UNDERSCORE_RE = re.compile(r"(?<=[^\-_])[\-_]+[^\-_]")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pyhumps"
-version = "3.8.0"
+version = "3.8.1"
 description = "Convert strings (and dictionary keys) between snake case, camel case and pascal case in Python."
 license = "The Unlicense (Unlicense)"
 authors = ["Nick Ficano <nficano@gmail.com>"]
@@ -27,9 +27,9 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.dev.dependencies]
 pytest = "^7.1.3"
 pylint = "^2.12.2"
 flake8 = "^5.0.4"

--- a/tests/test_humps.py
+++ b/tests/test_humps.py
@@ -24,6 +24,7 @@ def test_converting_strings():
         ("memMB", "mem_mb"),
         # Fixed issue #258
         ("B52Thing", "b52_thing"),
+        ("B2BThing", "b2b_thing"),
     ],
 )
 def test_camelized_acronyms(input_str, expected_output):


### PR DESCRIPTION
## Status
**READY**

## Description
Fix (again) #258 . All tests are passing, including ` test_camelized_acronyms[B52Thing-b52_thing]` not fixed in #274 nor #301. In addition run tests in python 3.12 and 3.13 in CI. 

## Related PRs

- Supersedes #301

